### PR TITLE
fix type in log line

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
     let mut server = Server::new(sock);
     server.register(&mut event_loop).ok().expect("Failed to register server with event loop");
 
-    info!("Even loop starting...");
+    info!("Event loop starting...");
     event_loop.run(&mut server).unwrap_or_else(|e| {
         error!("Event loop failed {:?}", e);
     });


### PR DESCRIPTION
This corrects the info log line that logs the event loop is starting.
