### PR TITLE
fixing mispelling and made some editing for readability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ rust:
   - nightly
   - beta
   - stable
+matrix:
+  allow_failures:
+    - rust: nightly
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ The client is just a very simple way to send a bunch of messages to the server.
 
 ### Logging
 
-I use the `env_logger` create. Logging can be turned on for mob-server with `RUST_LOG=mob_server ./target/debug/mob-server`. If you want to see the log output from mio as well, you can do `RUST_LOG=mob_server,mio ./target/debug/mob-server`.
+I use the `env_logger` crate. Logging can be turned on for mob-server with:
+```
+RUST_LOG=mob_server ./target/debug/mob-server  
+```
+If you want to see the log output from mio as well, you can do:
+```
+RUST_LOG=mob_server,mio ./target/debug/mob-server
+```
 
 ## Docker
 


### PR DESCRIPTION
"crate" was misspelled and the env_loggers lines were difficult to read so I made some README edits while making sure that the rust nightly ssl issues weren't just flakey.

Since the build is broken due to nightly's ssl issues, I also just let travis ignore nightly tests so you can have a green build when it's fixed or if you don't mind it being broken, you can revert the build matrix to not allowing nightly to fail. 

I just hate making a pull request that breaks a build even when it's a false negative. 
Looks like tomorrow's build will fix this:
[reddit link](https://www.reddit.com/r/rust/comments/5fjf7o/psa_cargo_nightly_on_linux_cant_fetch_the_index/)