### PR TITLE
document use of unsafe

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -75,6 +75,10 @@ impl Connection {
         let msg_len = msg_len as usize;
 
         debug!("Expected message length is {}", msg_len);
+        
+        // Here we allocate and set the length with unsafe code. The risks of this are discussed
+        // at https://stackoverflow.com/a/30979689/329496 and are mitigated as recv_buf is 
+        // abandoned below if we don't read msg_leg bytes from the socket
         let mut recv_buf : Vec<u8> = Vec::with_capacity(msg_len);
         unsafe { recv_buf.set_len(msg_len); }
 


### PR DESCRIPTION
Reading the code I saw the use of unsafe and had to read up on it and figure out how it wasn't going to unleash [nasal demons](http://catb.org/jargon/html/N/nasal-demons.html). I thought to add a comment to the code to explain it to others. 